### PR TITLE
Fix JENKINS-12696

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/urltrigger/URLTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/urltrigger/URLTrigger.java
@@ -138,6 +138,11 @@ public class URLTrigger extends AbstractTrigger {
         if (isAuthBasic(entry)) {
             addBasicAuth(entry, log, client);
         }
+        /* Set a connect and read timeout. If this hangs, it can actually
+           take down all of the jenkins schedule events.
+           This is 5 minutes expressed as milliseconds. */
+        client.setConnectTimeout(300000);
+        client.setReadTimeout(300000);
         return client;
     }
 


### PR DESCRIPTION
Add a timeout to the network activity.

This should address https://issues.jenkins-ci.org/browse/JENKINS-12696 which has now caused our scheduled jenkins jobs to stop working multiple times this week.
