### PR TITLE
Fix for bug JENKINS-20712

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/urltrigger/URLTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/urltrigger/URLTrigger/config.jelly
@@ -61,40 +61,36 @@
                     </f:entry>
 
                     <f:entry>
-                        <table style="width:100%">
-                            <f:checkbox
-                                    field="checkETag"
-                                    name="urlElements.checkETag"
-                                    checked="${urlElements.checkETag}"
-                                    title="${%Check ETag}">
-                            </f:checkbox>
-                        </table>
+                        <f:checkbox
+                                field="checkETag"
+                                name="urlElements.checkETag"
+                                checked="${urlElements.checkETag}"
+                                title="${%Check ETag}">
+                        </f:checkbox>
                     </f:entry>
 
                     <f:entry>
-                        <table style="width:100%">
-                            <f:checkbox
-                                    field="checkLastModificationDate"
-                                    name="urlElements.checkLastModificationDate"
-                                    checked="${urlElements.checkLastModificationDate}"
-                                    title="${%Check the last modification Date}">
-                            </f:checkbox>
-                        </table>
+                        <f:checkbox
+                                field="checkLastModificationDate"
+                                name="urlElements.checkLastModificationDate"
+                                checked="${urlElements.checkLastModificationDate}"
+                                title="${%Check the last modification Date}">
+                        </f:checkbox>
                     </f:entry>
 
                     <f:entry>
                         <table style="width:100%">
                             <f:optionalBlock
-                                    name="urlElements.inspectingContent"
-                                    field="inspectingContent"
-                                    checked="${urlElements.inspectingContent}"
-                                    title="${%Inspect URL content}">
+                                name="urlElements.inspectingContent"
+                                field="inspectingContent"
+                                checked="${urlElements.inspectingContent}"
+                                title="${%Inspect URL content}">
 
                                 <f:block>
                                     <f:hetero-list name="urlElements.contentTypes"
-                                                   descriptors="${descriptor.listURLTriggerDescriptors}"
-                                                   addCaption="${%Add a content nature}"
-                                                   items="${urlElements.contentTypes}"/>
+                                       descriptors="${descriptor.listURLTriggerDescriptors}"
+                                       addCaption="${%Add a content nature}"
+                                       items="${urlElements.contentTypes}"/>
                                 </f:block>
                             </f:optionalBlock>
                         </table>

--- a/src/main/resources/org/jenkinsci/plugins/urltrigger/URLTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/urltrigger/URLTrigger/config.jelly
@@ -65,8 +65,7 @@
                                 field="checkETag"
                                 name="urlElements.checkETag"
                                 checked="${urlElements.checkETag}"
-                                title="${%Check ETag}">
-                        </f:checkbox>
+                                title="${%Check ETag}"/>
                     </f:entry>
 
                     <f:entry>
@@ -74,8 +73,7 @@
                                 field="checkLastModificationDate"
                                 name="urlElements.checkLastModificationDate"
                                 checked="${urlElements.checkLastModificationDate}"
-                                title="${%Check the last modification Date}">
-                        </f:checkbox>
+                                title="${%Check the last modification Date}"/>
                     </f:entry>
 
                     <f:entry>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-20712
"Check ETag" (and "Check the last modification Date") was always unchecked on the Jenkins web page by default even if in the config it had a 'true' value
![check etag](https://cloud.githubusercontent.com/assets/2707008/8575202/751d9104-25a3-11e5-87fe-e3731e4a78be.png)
