### PR TITLE
chore(json/array): allow to use jsonarray as root of input message

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/urltrigger/content/json/util/JsonUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/urltrigger/content/json/util/JsonUtils.java
@@ -19,7 +19,7 @@ public class JsonUtils {
             if (currentToken.equals(JsonToken.START_OBJECT)) {
                 validateObject(parser);
             } else if (currentToken.equals(JsonToken.START_ARRAY)) {
-                throw new XTriggerException("Json documents starting with arrays are not supported!");
+                validateArray(parser);
             } else {
                 throw new XTriggerException("Bad Json value starting with: " + currentToken.toString());
             }

--- a/src/test/java/org/jenkinsci/plugins/urltrigger/content/JSONArrayContentTypeWithExpressionsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/urltrigger/content/JSONArrayContentTypeWithExpressionsTest.java
@@ -1,0 +1,35 @@
+package org.jenkinsci.plugins.urltrigger.content;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+
+public class JSONArrayContentTypeWithExpressionsTest extends AbstractJSONContentTypeTest {
+
+    public JSONArrayContentTypeWithExpressionsTest() {
+        JSONContentEntry[] expressions = new JSONContentEntry[]{new JSONContentEntry("$..name")};
+        type = new JSONContentType(Arrays.<JSONContentEntry>asList(expressions));
+    }
+
+    protected String getOldContentNotEmpty() throws IOException, URISyntaxException {
+        return readContentAsString("json/expressions/oldGitHubContent.json");
+    }
+
+    protected String getNewContent() throws IOException, URISyntaxException {
+        return readContentAsString("json/expressions/newGitHubContent.json");
+    }
+
+    @Test
+    public void testIsTriggeringMatchingNewContentWithEmptyPreviousContent() throws Exception {
+        Assert.assertTrue(isTriggeringBuildForContentWithChange_EmptyTypePreviousContent());
+    }
+
+    @Test
+    public void testIsTriggeringMatchingNewContentWithMatchingPreviousContent() throws Exception {
+        Assert.assertTrue(isTriggeringBuildForContentWithChange_AnyContentPreviousContent());
+    }
+}
+

--- a/src/test/resources/org/jenkinsci/plugins/urltrigger/content/json/expressions/newGitHubContent.json
+++ b/src/test/resources/org/jenkinsci/plugins/urltrigger/content/json/expressions/newGitHubContent.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "v3.0.3",
+    "zipball_url": "https://api.github.com/repos/hawky-4s-/test-repo/zipball/v3.0.3",
+    "tarball_url": "https://api.github.com/repos/hawky-4s-/test-repo/tarball/v3.0.3",
+    "commit": {
+      "sha": "11ff5f62ffaaadea50118fb4010eac6aff14a98c",
+      "url": "https://api.github.com/repos/hawky-4s-/test-repo/commits/11ff5f62ffaaadea50118fb4010eac6aff14a98c"
+    }
+  }
+]

--- a/src/test/resources/org/jenkinsci/plugins/urltrigger/content/json/expressions/oldGitHubContent.json
+++ b/src/test/resources/org/jenkinsci/plugins/urltrigger/content/json/expressions/oldGitHubContent.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "v3.0.2",
+    "zipball_url": "https://api.github.com/repos/hawky-4s-/test-repo/zipball/v3.0.2",
+    "tarball_url": "https://api.github.com/repos/hawky-4s-/test-repo/tarball/v3.0.2",
+    "commit": {
+      "sha": "11ff5f62ffaaadea50118fb4010eac6aff14a98b",
+      "url": "https://api.github.com/repos/hawky-4s-/test-repo/commits/11ff5f62ffaaadea50118fb4010eac6aff14a98b"
+    }
+  }
+]


### PR DESCRIPTION
We would like to use the URL Trigger Plugin to poll a JSON API which returns a JSON array. Like the GitHub Tags API. We aren't aware of any reason to not support it. It works for us in production.