### PR TITLE
Fix for JENKINS-33691 URLTrigger Plugin doesn't work in jenkins 2.0 alpha 3 when using job type Pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
-        <xtrigger.lib.version>0.33</xtrigger.lib.version>
+        <xtrigger.lib.version>0.34-SNAPSHOT</xtrigger.lib.version>
         <jersey.client.version>1.9.1</jersey.client.version>
         <json.path.version>0.5.5</json.path.version>
         <jackson.mapper.as1.version>1.8.3</jackson.mapper.as1.version>
@@ -52,6 +52,12 @@
             <groupId>org.jenkins-ci.lib</groupId>
             <artifactId>xtrigger-lib</artifactId>
             <version>${xtrigger.lib.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>envinject-api</artifactId>
+            <version>1.2</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/urltrigger/URLTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/urltrigger/URLTrigger.java
@@ -26,11 +26,11 @@ import org.apache.commons.httpclient.auth.AuthScope;
 import org.apache.commons.jelly.XMLOutput;
 import org.apache.commons.net.ftp.FTPClient;
 import org.jenkinsci.lib.envinject.EnvInjectException;
-import org.jenkinsci.lib.envinject.service.EnvVarsResolver;
 import org.jenkinsci.lib.xtrigger.AbstractTrigger;
 import org.jenkinsci.lib.xtrigger.XTriggerDescriptor;
 import org.jenkinsci.lib.xtrigger.XTriggerException;
 import org.jenkinsci.lib.xtrigger.XTriggerLog;
+import org.jenkinsci.plugins.envinjectapi.util.EnvVarsResolver;
 import org.jenkinsci.plugins.urltrigger.content.URLTriggerContentType;
 import org.jenkinsci.plugins.urltrigger.content.URLTriggerContentTypeDescriptor;
 import org.jenkinsci.plugins.urltrigger.service.FTPResponse;
@@ -132,8 +132,8 @@ public class URLTrigger extends AbstractTrigger {
         }
 
         @SuppressWarnings("unused")
-        public AbstractProject<?, ?> getOwner() {
-            return (AbstractProject) job;
+        public Job<?, ?> getOwner() {
+            return (Job<?, ?>) job;
         }
 
         @SuppressWarnings("unused")
@@ -176,10 +176,9 @@ public class URLTrigger extends AbstractTrigger {
     private String getURLValue(URLTriggerEntry entry, Node node) throws XTriggerException {
         String entryURL = entry.getUrl();
         if (entryURL != null) {
-            EnvVarsResolver varsRetriever = new EnvVarsResolver();
             Map<String, String> envVars;
             try {
-                envVars = varsRetriever.getPollingEnvVars((AbstractProject) job, node);
+                envVars = EnvVarsResolver.getPollingEnvVars((Job<?, ?>) job, node);
             } catch (EnvInjectException e) {
                 throw new XTriggerException(e);
             }


### PR DESCRIPTION
Here I update to the `xtrigger-lib` from [my last pull request](https://github.com/jenkinsci/xtrigger-lib/pull/8) and update EnvInject to the latest version (which supports pipelines). I also continue the work done in the previous pull request to support pipeline jobs by using the appropriate types.

Testing done:

For both freestyle and pipeline jobs, I created a job with a URL trigger and set the cron string to every minute (using the Jenkins UI). I then watched for a few minutes. The polling took place as expected and the polling log was visible in the UI. When the URL changed, the job was rebuilt. The cause of the rebuild was visible in the UI, as was the polling log.