### PR TITLE
URLTriggerService.java: save log if content has changed

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/urltrigger/service/URLTriggerService.java
+++ b/src/main/java/org/jenkinsci/plugins/urltrigger/service/URLTriggerService.java
@@ -162,6 +162,7 @@ public class URLTriggerService {
             if (type != null) {
                 boolean isTriggering = type.isTriggering(content, log);
                 if (isTriggering) {
+                    log.info("The content has changed.");
                     return true;
                 }
             }


### PR DESCRIPTION
When there are multiple url listened, it would be more clear if saving content
change information to log. Like other method does.

Signed-off-by: Xiao Liang <xiliang@redhat.com>