### PR TITLE
Enable JDK11 in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,4 @@
 buildPlugin(configurations: [
-  [platform: 'linux', jdk: '8'],
   [platform: 'linux', jdk: '11'],
-  [platform: 'windows', jdk: '8'],
   [platform: 'windows', jdk: '11']
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,6 @@
-buildPlugin(configurations: [
-  [platform: 'linux', jdk: '11'],
-  [platform: 'windows', jdk: '11']
-])
+buildPlugin(platforms: ['linux', 'windows'], jdkVersions: ['8', '11'],
+  configurations: [
+    [platform: 'linux', jdk: '11'],
+    [platform: 'windows', jdk: '11']
+  ]
+)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,6 @@
-buildPlugin()
+buildPlugin(configurations: [
+  [platform: 'linux', jdk: '8'],
+  [platform: 'linux', jdk: '11'],
+  [platform: 'windows', jdk: '8'],
+  [platform: 'windows', jdk: '11']
+])

--- a/pom.xml
+++ b/pom.xml
@@ -41,14 +41,13 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<java.version>1.8.0</java.version>
 		<java.level>8</java.level>
 		<xtrigger.lib.version>0.35</xtrigger.lib.version>
 		<jersey.client.version>1.19.4</jersey.client.version>
-		<json.path.version>2.4.0</json.path.version>
+		<json.path.version>2.6.0</json.path.version>
 		<jackson.mapper.as1.version>1.8.3</jackson.mapper.as1.version>
 		<mockito.version>1.8.5</mockito.version>
-		<jenkins.version>2.204.6</jenkins.version>
+		<jenkins.version>2.263.4</jenkins.version>
 	</properties>
 
 	<scm>
@@ -73,8 +72,8 @@
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.204.x</artifactId>
-				<version>16</version>
+				<artifactId>bom-2.263.x</artifactId>
+				<version>950.v396cb834de1e</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,6 @@
 			<artifactId>structs</artifactId>
 		</dependency>
 
-
 		<dependency>
 			<groupId>org.jenkins-ci.lib</groupId>
 			<artifactId>xtrigger-lib</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>4.12</version>
+		<version>4.29</version>
 	</parent>
 
 	<artifactId>urltrigger</artifactId>
@@ -39,8 +39,6 @@
 		<changelist>-SNAPSHOT</changelist>
 		<gitHubRepo>jenkinsci/urltrigger-plugin</gitHubRepo>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 		<java.level>8</java.level>
 		<xtrigger.lib.version>0.35</xtrigger.lib.version>
 		<jersey.client.version>1.19.4</jersey.client.version>
@@ -141,7 +139,7 @@
 		<dependency>
 			<groupId>commons-net</groupId>
 			<artifactId>commons-net</artifactId>
-			<version>3.6</version>
+			<version>3.8.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Here is a simple PR enabling JDK11 in the Jenkinsfile of this plugin, helping the global support of Java 11 in Jenkins plugins.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] ~~Link to relevant issues in GitHub or Jira~~
- [X] ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
