### PR TITLE
Update libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>io.jenkins.plugins</groupId>
 			<artifactId>jersey2-api</artifactId>
-			<version>2.35-2</version>
+			<version>2.35-3</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<java.level>8</java.level>
 		<xtrigger.lib.version>0.36</xtrigger.lib.version>
-		<jersey.client.version>1.19.4</jersey.client.version>
 		<json.path.version>2.6.0</json.path.version>
-		<jackson.mapper.as1.version>1.8.3</jackson.mapper.as1.version>
 		<mockito.version>1.8.5</mockito.version>
 		<jenkins.version>2.263.4</jenkins.version>
 	</properties>
@@ -100,26 +98,17 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.sun.jersey</groupId>
-			<artifactId>jersey-client</artifactId>
-			<version>${jersey.client.version}</version>
+			<groupId>io.jenkins.plugins</groupId>
+			<artifactId>jersey2-api</artifactId>
+			<version>2.35-2</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.sun.jersey.contribs</groupId>
-			<artifactId>jersey-apache-client</artifactId>
-			<version>${jersey.client.version}</version>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>apache-httpcomponents-client-4-api</artifactId>
+			<version>4.5.13-1.0</version>
 		</dependency>
 
-		<dependency>
-			<groupId>commons-httpclient</groupId>
-			<artifactId>commons-httpclient</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>commons-codec</groupId>
-			<artifactId>commons-codec</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-job</artifactId>
@@ -133,20 +122,15 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-mapper-asl</artifactId>
-			<version>${jackson.mapper.as1.version}</version>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>jackson2-api</artifactId>
+			<version>2.13.1-246.va8a9f3eaf46a</version>
 		</dependency>
 
 		<dependency>
 			<groupId>commons-net</groupId>
 			<artifactId>commons-net</artifactId>
 			<version>3.6</version>
-		</dependency>
-
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/jenkinsci/plugins/urltrigger/URLTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/urltrigger/URLTrigger.java
@@ -24,6 +24,8 @@ import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 import org.apache.commons.jelly.XMLOutput;
 import org.apache.commons.net.ftp.FTPClient;
+import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
+import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.ClientResponse;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
@@ -451,6 +453,7 @@ public class URLTrigger extends AbstractTrigger {
             config.property(ClientProperties.PROXY_USERNAME, p.getUserName());
             String password = getProxyPasswordDecrypted(p);
             config.property(ClientProperties.PROXY_PASSWORD, Util.fixNull(password));
+            config.withConfig(new ClientConfig().connectorProvider(new ApacheConnectorProvider()));
         }
 
         //-- Https

--- a/src/main/java/org/jenkinsci/plugins/urltrigger/URLTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/urltrigger/URLTrigger.java
@@ -27,7 +27,6 @@ import org.apache.commons.net.ftp.FTPClient;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
-import org.glassfish.jersey.client.ClientResponse;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.envinject.EnvInjectException;
@@ -55,6 +54,8 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -297,7 +298,7 @@ public class URLTrigger extends AbstractTrigger {
         }
         
         log.info(String.format("Invoking the url: %n %s", url));
-        ClientResponse clientResponse = webResourceBuilder.get(ClientResponse.class);
+        Response clientResponse = webResourceBuilder.get();
 
         URLTriggerEntry entry = resolvedEntry.getEntry();
 
@@ -332,12 +333,12 @@ public class URLTrigger extends AbstractTrigger {
 
     }
 
-    private boolean isServiceUnavailableAndNotExpected(ClientResponse clientResponse, URLTriggerEntry entry) {
+    private boolean isServiceUnavailableAndNotExpected(Response clientResponse, URLTriggerEntry entry) {
         return HttpServletResponse.SC_SERVICE_UNAVAILABLE == clientResponse.getStatus()
                 && entry.getStatusCode() != HttpServletResponse.SC_SERVICE_UNAVAILABLE;
     }
 
-    private boolean isURLNotFoundAndNotExpected( ClientResponse clientResponse , URLTriggerEntry entry ) {
+    private boolean isURLNotFoundAndNotExpected(Response clientResponse , URLTriggerEntry entry ) {
     		return HttpServletResponse.SC_NOT_FOUND == clientResponse.getStatus()
     				&& entry.getStatusCode() != HttpServletResponse.SC_NOT_FOUND ;
     }

--- a/src/main/java/org/jenkinsci/plugins/urltrigger/URLTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/urltrigger/URLTrigger.java
@@ -3,15 +3,6 @@ package org.jenkinsci.plugins.urltrigger;
 import antlr.ANTLRException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.api.client.config.ClientConfig;
-import com.sun.jersey.api.client.config.DefaultClientConfig;
-import com.sun.jersey.api.client.filter.HTTPBasicAuthFilter;
-import com.sun.jersey.client.apache.ApacheHttpClient;
-import com.sun.jersey.client.apache.config.DefaultApacheHttpClientConfig;
-import com.sun.jersey.client.urlconnection.HTTPSProperties;
 import hudson.DescriptorExtensionList;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -31,9 +22,11 @@ import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
-import org.apache.commons.httpclient.auth.AuthScope;
 import org.apache.commons.jelly.XMLOutput;
 import org.apache.commons.net.ftp.FTPClient;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.ClientResponse;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 import org.jenkinsci.lib.envinject.service.EnvVarsResolver;
@@ -57,6 +50,9 @@ import org.kohsuke.stapler.StaplerRequest;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Invocation;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -69,6 +65,7 @@ import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -287,7 +284,7 @@ public class URLTrigger extends AbstractTrigger {
         Client client = getClientObject(resolvedEntry, log);
 
         String url = resolvedEntry.getResolvedURL();
-        WebResource.Builder webResourceBuilder = client.resource(url).getRequestBuilder() ;
+        Invocation.Builder webResourceBuilder = client.target(url).request();
         
         List< URLTriggerRequestHeader > requestHeaders = resolvedEntry.getEntry().getRequestHeaders() ;
         if( requestHeaders.size() > 0 ) {
@@ -361,27 +358,20 @@ public class URLTrigger extends AbstractTrigger {
     private Client getClientObject(URLTriggerResolvedEntry resolvedEntry, XTriggerLog log) throws XTriggerException {
 
         URLTriggerEntry entry = resolvedEntry.getEntry();
-        Client client = createClient(resolvedEntry.isHttps(), entry.isProxyActivated());
+        Client client = createClient(resolvedEntry.isHttps(), entry.isProxyActivated(), entry.getTimeout());
         if (isAuthBasic(entry)) {
             addBasicAuth(entry, log, client);
         }
 
-        /* Set a connect and read timeout. If this hangs, it can actually
-           take down all of the jenkins schedule events.
-        */
-        int timeout = entry.getTimeout();
-        client.setConnectTimeout(timeout * 1000); //in milliseconds
-        client.setReadTimeout(timeout * 1000);    //in milliseconds
-
         return client;
     }
 
-    private Client createClient(boolean isHttps, boolean withProxy) throws XTriggerException {
+    private Client createClient(boolean isHttps, boolean withProxy, int timeout) throws XTriggerException {
         Client client;
         if (withProxy) {
-            client = createClientWithProxy(isHttps);
+            client = createClientWithProxy(isHttps, timeout);
         } else {
-            client = createClientWithoutProxy(isHttps);
+            client = createClientWithoutProxy(isHttps, timeout);
         }
         return client;
     }
@@ -391,15 +381,24 @@ public class URLTrigger extends AbstractTrigger {
             log.info(String.format("Using Basic Authentication with the user '%s'", entry.getUsername()));
         }
         String password = entry.getRealPassword();
-        client.addFilter(new HTTPBasicAuthFilter(entry.getUsername(), password));
+        client.register(HttpAuthenticationFeature.basic(entry.getUsername(), password));
     }
 
-    private Client createClientWithoutProxy(boolean isHttps) throws XTriggerException {
-        ClientConfig config = new DefaultClientConfig();
+    private Client createClientWithoutProxy(boolean isHttps, int timeout) throws XTriggerException {
+        ClientBuilder config = ClientBuilder.newBuilder();
         if (isHttps) {
-            config.getProperties().put(HTTPSProperties.PROPERTY_HTTPS_PROPERTIES, new HTTPSProperties(getHostnameVerifier(), getSSLContext()));
+            config.sslContext(getSSLContext());
+            config.hostnameVerifier(getHostnameVerifier());
         }
-        return Client.create(config);
+
+        /*
+         * Set a connect and read timeout. If this hangs, it can actually
+         * take down all of the Jenkins schedule events.
+         */
+        config.connectTimeout(timeout, TimeUnit.SECONDS);
+        config.readTimeout(timeout, TimeUnit.SECONDS);
+
+        return config.build();
     }
 
     private HostnameVerifier getHostnameVerifier() {
@@ -441,26 +440,33 @@ public class URLTrigger extends AbstractTrigger {
     }
 
 
-    private Client createClientWithProxy(boolean isHttps) throws XTriggerException {
-        Client client;
-        DefaultApacheHttpClientConfig config = new DefaultApacheHttpClientConfig();
+    private Client createClientWithProxy(boolean isHttps, int timeout) throws XTriggerException {
+        ClientBuilder config = ClientBuilder.newBuilder();
 
         //-- Proxy
         Jenkins h = Jenkins.get(); // this code might run on slaves
         ProxyConfiguration p = h.proxy ;
         if (p != null) {
-            config.getProperties().put(DefaultApacheHttpClientConfig.PROPERTY_PROXY_URI, "http://" + p.name + ":" + p.port);
+            config.property(ClientProperties.PROXY_URI, "http://" + p.name + ":" + p.port);
+            config.property(ClientProperties.PROXY_USERNAME, p.getUserName());
             String password = getProxyPasswordDecrypted(p);
-            config.getState().setProxyCredentials(AuthScope.ANY_REALM, p.name, p.port, p.getUserName(), Util.fixNull(password));
+            config.property(ClientProperties.PROXY_PASSWORD, Util.fixNull(password));
         }
 
         //-- Https
         if (isHttps) {
-            config.getProperties().put(HTTPSProperties.PROPERTY_HTTPS_PROPERTIES, new HTTPSProperties(getHostnameVerifier(), getSSLContext()));
+            config.sslContext(getSSLContext());
+            config.hostnameVerifier(getHostnameVerifier());
         }
 
-        client = ApacheHttpClient.create(config);
-        return client;
+        /*
+         * Set a connect and read timeout. If this hangs, it can actually
+         * take down all of the Jenkins schedule events.
+         */
+        config.connectTimeout(timeout, TimeUnit.SECONDS);
+        config.readTimeout(timeout, TimeUnit.SECONDS);
+
+        return config.build();
     }
 
     private String getProxyPasswordDecrypted(ProxyConfiguration p) {

--- a/src/main/java/org/jenkinsci/plugins/urltrigger/URLTriggerEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/urltrigger/URLTriggerEntry.java
@@ -1,7 +1,5 @@
 package org.jenkinsci.plugins.urltrigger;
 
-import com.sun.jersey.api.client.ClientResponse;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Describable;
@@ -17,6 +15,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.ws.rs.core.Response;
+
 /**
  * @author Gregory Boissinot
  */
@@ -24,7 +24,7 @@ public class URLTriggerEntry implements Serializable , Describable< URLTriggerEn
 
 	private static final long serialVersionUID = -7232627326475916056L;
 
-	public static final int DEFAULT_STATUS_CODE = ClientResponse.Status.OK.getStatusCode();
+	public static final int DEFAULT_STATUS_CODE = Response.Status.OK.getStatusCode();
 
     private String url;
     private String username;

--- a/src/main/java/org/jenkinsci/plugins/urltrigger/content/json/util/JsonUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/urltrigger/content/json/util/JsonUtils.java
@@ -1,8 +1,8 @@
 package org.jenkinsci.plugins.urltrigger.content.json.util;
 
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonToken;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import org.jenkinsci.lib.xtrigger.XTriggerException;
 
 import java.io.IOException;

--- a/src/main/java/org/jenkinsci/plugins/urltrigger/service/HTTPResponse.java
+++ b/src/main/java/org/jenkinsci/plugins/urltrigger/service/HTTPResponse.java
@@ -1,7 +1,5 @@
 package org.jenkinsci.plugins.urltrigger.service;
 
-import org.glassfish.jersey.client.ClientResponse;
-
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Response;
 import java.util.Date;
@@ -11,9 +9,9 @@ import java.util.Date;
  */
 public class HTTPResponse implements URLResponse {
 
-    private ClientResponse baseResponse;
+    private Response baseResponse;
 
-    public HTTPResponse(ClientResponse clientResponse) {
+    public HTTPResponse(Response clientResponse) {
         baseResponse = clientResponse;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/urltrigger/service/HTTPResponse.java
+++ b/src/main/java/org/jenkinsci/plugins/urltrigger/service/HTTPResponse.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.urltrigger.service;
 
-import com.sun.jersey.api.client.ClientResponse;
+import org.glassfish.jersey.client.ClientResponse;
 
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Response;
@@ -22,7 +22,7 @@ public class HTTPResponse implements URLResponse {
     }
 
     public String getContent() {
-        return baseResponse.getEntity(String.class);
+        return baseResponse.readEntity(String.class);
     }
 
     public int getStatus() {
@@ -38,7 +38,7 @@ public class HTTPResponse implements URLResponse {
     }
 
     public boolean isSuccessfullFamily() {
-        return baseResponse.getClientResponseStatus().getFamily() == Response.Status.Family.SUCCESSFUL;
+        return baseResponse.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL;
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/urltrigger/service/URLTriggerServiceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/urltrigger/service/URLTriggerServiceTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.urltrigger.service;
 
-import com.sun.jersey.api.client.ClientResponse;
+import org.glassfish.jersey.client.ClientResponse;
 import hudson.model.TaskListener;
 import hudson.util.StreamTaskListener;
 import org.jenkinsci.lib.xtrigger.XTriggerException;
@@ -37,7 +37,7 @@ public class URLTriggerServiceTest {
     public void init() {
         MockitoAnnotations.initMocks(this);
         urlTriggerService = URLTriggerService.getInstance();
-        when(clientResponseMock.getClientResponseStatus()).thenReturn(ClientResponse.Status.OK);
+        when(clientResponseMock.getStatusInfo()).thenReturn(Response.Status.OK);
     }
 
     @Test
@@ -68,7 +68,7 @@ public class URLTriggerServiceTest {
         when(urlTriggerEntryMock.isInspectingContent()).thenReturn(true);
         URLTriggerContentType urlTriggerContentTypeMock = mock(URLTriggerContentType.class);
         when(urlTriggerEntryMock.getContentTypes()).thenReturn(new URLTriggerContentType[]{urlTriggerContentTypeMock});
-        when(clientResponseMock.getEntity(String.class)).thenReturn(null);
+        when(clientResponseMock.readEntity(String.class)).thenReturn(null);
 
         urlTriggerService.initContent(new HTTPResponse(clientResponseMock), urlTriggerEntryMock, log);
     }
@@ -86,7 +86,7 @@ public class URLTriggerServiceTest {
         when(urlTriggerEntryMock.isInspectingContent()).thenReturn(true);
         URLTriggerContentType urlTriggerContentTypeMock = mock(URLTriggerContentType.class);
         when(urlTriggerEntryMock.getContentTypes()).thenReturn(new URLTriggerContentType[]{urlTriggerContentTypeMock});
-        when(clientResponseMock.getEntity(String.class)).thenReturn(contentStub);
+        when(clientResponseMock.readEntity(String.class)).thenReturn(contentStub);
 
         urlTriggerService.initContent(new HTTPResponse(clientResponseMock), urlTriggerEntryMock, log);
 
@@ -127,7 +127,7 @@ public class URLTriggerServiceTest {
     private void verifyIsSchedulingForURLEntryCheckLastModificationDate(URLTriggerEntry urlEntryMock, Date responseDate) {
         verify(clientResponseMock, never()).getStatus();
         verify(clientResponseMock, times(1)).getLastModified();
-        verify(clientResponseMock, never()).getEntity(String.class);
+        verify(clientResponseMock, never()).readEntity(String.class);
 
         verify(urlEntryMock, times(1)).isCheckStatus();
         verify(urlEntryMock, never()).getStatusCode();
@@ -186,7 +186,7 @@ public class URLTriggerServiceTest {
 
         verify(clientResponseMock, never()).getStatus();
         verify(clientResponseMock, never()).getLastModified();
-        verify(clientResponseMock, times(1)).getEntity(String.class);
+        verify(clientResponseMock, times(1)).readEntity(String.class);
     }
 
     @Test
@@ -198,7 +198,7 @@ public class URLTriggerServiceTest {
         when(urlEntryMock.isCheckLastModificationDate()).thenReturn(false);
         when(urlEntryMock.isInspectingContent()).thenReturn(true);
         when(urlEntryMock.getContentTypes()).thenReturn(new URLTriggerContentType[]{contentTypeMock});
-        when(clientResponseMock.getEntity(Matchers.any(Class.class))).thenReturn(null);
+        when(clientResponseMock.readEntity(Matchers.any(Class.class))).thenReturn(null);
 
         urlTriggerService.isSchedulingAndGetRefresh(new HTTPResponse(clientResponseMock), urlEntryMock, mock(XTriggerLog.class));
         Assert.assertFalse(false);
@@ -212,7 +212,7 @@ public class URLTriggerServiceTest {
 
         verify(clientResponseMock, never()).getStatus();
         verify(clientResponseMock, never()).getLastModified();
-        verify(clientResponseMock, times(1)).getEntity(String.class);
+        verify(clientResponseMock, times(1)).readEntity(String.class);
 
         verify(contentTypeMock, never()).isTriggering(anyString(), any(XTriggerLog.class));
     }
@@ -225,7 +225,7 @@ public class URLTriggerServiceTest {
         when(urlEntryMock.isCheckLastModificationDate()).thenReturn(false);
         when(urlEntryMock.isInspectingContent()).thenReturn(true);
         when(urlEntryMock.getContentTypes()).thenReturn(new URLTriggerContentType[]{contentTypeMock});
-        when(clientResponseMock.getEntity(Matchers.any(Class.class))).thenReturn("S");
+        when(clientResponseMock.readEntity(Matchers.any(Class.class))).thenReturn("S");
         when(contentTypeMock.isTriggering(Matchers.any(String.class), Matchers.any(XTriggerLog.class))).thenReturn(isTriggeringBuildContent);
 
         boolean result = urlTriggerService.isSchedulingAndGetRefresh(new HTTPResponse(clientResponseMock), urlEntryMock, mock(XTriggerLog.class));
@@ -240,7 +240,7 @@ public class URLTriggerServiceTest {
 
         verify(clientResponseMock, never()).getStatus();
         verify(clientResponseMock, never()).getLastModified();
-        verify(clientResponseMock, times(1)).getEntity(String.class);
+        verify(clientResponseMock, times(1)).readEntity(String.class);
 
         verify(contentTypeMock, times(1)).isTriggering(anyString(), any(XTriggerLog.class));
     }

--- a/src/test/java/org/jenkinsci/plugins/urltrigger/service/URLTriggerServiceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/urltrigger/service/URLTriggerServiceTest.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.urltrigger.service;
 
-import org.glassfish.jersey.client.ClientResponse;
 import hudson.model.TaskListener;
 import hudson.util.StreamTaskListener;
 import org.jenkinsci.lib.xtrigger.XTriggerException;
@@ -27,7 +26,7 @@ import static org.mockito.Mockito.*;
 public class URLTriggerServiceTest {
 
     @Mock
-    private ClientResponse clientResponseMock;
+    private Response clientResponseMock;
 
     private XTriggerLog log = new XTriggerLog((StreamTaskListener) TaskListener.NULL);
 


### PR DESCRIPTION
**Untested** PR that should fix jenkinsci/urltrigger-plugin#45 by:

- Updating Jersey from 1.19.4 to 2.35 and depending on the [Jersey 2 API](https://plugins.jenkins.io/jersey2-api/) plugin rather than embedding the JAR
- Updating Apache Commons HttpClient to 4.5.13 and depending on the [Apache HttpComponents Client 4.x API](https://plugins.jenkins.io/apache-httpcomponents-client-4-api/) plugin rather than embedding the JAR
- Updating Jackson from 1.8.3 to 2.13.1 and depending on the [Jackson 2 API](https://plugins.jenkins.io/jackson2-api/) plugin rather than embedding the JAR
- Removing the unused Commons Codec and Commons Lang dependencies from this plugin