### PR TITLE
fixed initialization order behind proxy

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/urltrigger/URLTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/urltrigger/URLTrigger.java
@@ -450,11 +450,11 @@ public class URLTrigger extends AbstractTrigger {
         Jenkins h = Jenkins.get(); // this code might run on slaves
         ProxyConfiguration p = h.proxy ;
         if (p != null) {
-            config.property(ClientProperties.PROXY_URI, "http://" + p.name + ":" + p.port);
+            config.withConfig(new ClientConfig().connectorProvider(new ApacheConnectorProvider()));
+	    config.property(ClientProperties.PROXY_URI, "http://" + p.name + ":" + p.port);
             config.property(ClientProperties.PROXY_USERNAME, p.getUserName());
             String password = getProxyPasswordDecrypted(p);
             config.property(ClientProperties.PROXY_PASSWORD, Util.fixNull(password));
-            config.withConfig(new ClientConfig().connectorProvider(new ApacheConnectorProvider()));
         }
 
         //-- Https


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [ x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

I fixed the order because the withConfig Method creates internally a new config so that the proxy settings are lost.
I tested it with our Jenkins instance behind the proxy.

Error comes up with https://github.com/jenkinsci/urltrigger-plugin/issues/48

