### PR TITLE
Bump `json-path` from 2.6.0 to 2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,13 @@
 			<groupId>com.jayway.jsonpath</groupId>
 			<artifactId>json-path</artifactId>
 			<version>${json.path.version}</version>
+			<exclusions>
+				<!-- Provided by Jenkins core -->
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.level>8</java.level>
 		<xtrigger.api.version>0.3</xtrigger.api.version>
-		<json.path.version>2.6.0</json.path.version>
+		<json.path.version>2.7.0</json.path.version>
 		<jenkins.version>2.263.4</jenkins.version>
 	</properties>
 


### PR DESCRIPTION
Supersedes #54. Resolves the Enforcer error by excluding SLF4J. Core already bundles SLF4J, so there is no need for this plugin to bundle it separately; moreover, the [Jenkins class loading model](https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/) means that core's version is used at runtime anyway.

CC @TonyNoble