### PR TITLE
Update plugin POM and BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>4.38</version>
+		<version>4.40</version>
 		<relativePath />
 	</parent>
 
@@ -35,10 +35,9 @@
 		<changelist>-SNAPSHOT</changelist>
 		<gitHubRepo>jenkinsci/urltrigger-plugin</gitHubRepo>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.level>8</java.level>
 		<xtrigger.api.version>0.4</xtrigger.api.version>
 		<json.path.version>2.7.0</json.path.version>
-		<jenkins.version>2.263.4</jenkins.version>
+		<jenkins.version>2.289.1</jenkins.version>
 	</properties>
 
 	<scm>
@@ -63,8 +62,8 @@
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.263.x</artifactId>
-				<version>984.vb5eaac999a7e</version>
+				<artifactId>bom-2.289.x</artifactId>
+				<version>1289.v5c4b_1c43511b_</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
@@ -93,13 +92,11 @@
 		<dependency>
 			<groupId>io.jenkins.plugins</groupId>
 			<artifactId>jersey2-api</artifactId>
-			<version>2.35-4</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>apache-httpcomponents-client-4-api</artifactId>
-			<version>4.5.13-1.0</version>
 		</dependency>
 
 		<dependency>
@@ -124,7 +121,6 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>jackson2-api</artifactId>
-			<version>2.13.2-260.v43d711474c77</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Updates the plugin parent POM and plugin BOM to the latest versions. The latter enables us to remove explicit version numbers for the plugins we depend on and instead get these version numbers from the BOM.

CC @TonyNoble 