### PR TITLE
Allow follow 302 redirects

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/urltrigger/URLTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/urltrigger/URLTrigger.java
@@ -361,7 +361,7 @@ public class URLTrigger extends AbstractTrigger {
         if (isAuthBasic(entry)) {
             addBasicAuth(entry, log, client);
         }
-
+        client.property(ClientProperties.FOLLOW_REDIRECTS, entry.isFollowRedirects());
         return client;
     }
 
@@ -637,6 +637,7 @@ public class URLTrigger extends AbstractTrigger {
         private URLTriggerEntry fillAndGetEntry(StaplerRequest req, JSONObject entryObject) {
             URLTriggerEntry urlTriggerEntry = new URLTriggerEntry();
             urlTriggerEntry.setUrl(entryObject.getString("url"));
+            urlTriggerEntry.setFollowRedirects(entryObject.getBoolean("followRedirects"));
             urlTriggerEntry.setProxyActivated(entryObject.getBoolean("proxyActivated"));
             urlTriggerEntry.setUseGlobalEnvVars(entryObject.getBoolean("useGlobalEnvVars"));
             String username = Util.fixEmpty(entryObject.getString("username"));

--- a/src/main/java/org/jenkinsci/plugins/urltrigger/URLTriggerEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/urltrigger/URLTriggerEntry.java
@@ -29,6 +29,7 @@ public class URLTriggerEntry implements Serializable , Describable< URLTriggerEn
     private String url;
     private String username;
     private String password;
+    private boolean followRedirects = false ;
     private boolean proxyActivated = false ;
     private boolean checkStatus = false ;
     private int statusCode;
@@ -59,10 +60,11 @@ public class URLTriggerEntry implements Serializable , Describable< URLTriggerEn
     	this.url = url ;
     }
   
-    public URLTriggerEntry(String url, String username, String password, boolean proxyActivated, boolean checkStatus, int statusCode, int timeout, boolean checkETag, boolean checkLastModificationDate, boolean inspectingContent, URLTriggerContentType[] contentTypes, String ETag, long lastModificationDate) {
+    public URLTriggerEntry(String url, String username, String password, boolean followRedirects, boolean proxyActivated, boolean checkStatus, int statusCode, int timeout, boolean checkETag, boolean checkLastModificationDate, boolean inspectingContent, URLTriggerContentType[] contentTypes, String ETag, long lastModificationDate) {
         this.url = url;
         this.username = username;
         this.password = password;
+        this.followRedirects = followRedirects;
         this.proxyActivated = proxyActivated;
         this.checkStatus = checkStatus;
         this.statusCode = statusCode;
@@ -109,6 +111,15 @@ public class URLTriggerEntry implements Serializable , Describable< URLTriggerEn
     @DataBoundSetter
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public boolean isFollowRedirects() {
+        return followRedirects;
+    }
+
+    @DataBoundSetter
+    public void setFollowRedirects(boolean followRedirects) {
+        this.followRedirects = followRedirects;
     }
 
     public boolean isProxyActivated() {

--- a/src/main/resources/org/jenkinsci/plugins/urltrigger/URLTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/urltrigger/URLTrigger/config.jelly
@@ -22,6 +22,14 @@
                                 title="${%Activate the Jenkins Proxy}"/>
                     </f:entry>
 
+                    <f:entry field="followRedirects">
+                        <f:checkbox
+                                field="followRedirects"
+                                name="urlElements.followRedirects"
+                                checked="${urlElements.followRedirects}"
+                                title="${%Follow Redirects}"/>
+                    </f:entry>
+
                     <f:entry field="useGlobalEnvVars">
                         <f:checkbox
                                 field="useGlobalEnvVars"

--- a/src/main/resources/org/jenkinsci/plugins/urltrigger/URLTrigger/help-followRedirects.html
+++ b/src/main/resources/org/jenkinsci/plugins/urltrigger/URLTrigger/help-followRedirects.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        Follow redirects.
+    </p>
+</div>


### PR DESCRIPTION
Some urls are hosted by a cdn networks, and for the real data, public url is redirected to the real cdn server.

Sample:

    curl -v -o /dev/null https://packagecloud.io/slacktechnologies/slack/debian/dists/jessie/main/binary-amd64/Packages
    ...
    < HTTP/1.1 302 Found
    < Date: Sun, 11 Feb 2024 00:13:14 GMT
    < Content-Type: text/html;charset=utf-8
    < Content-Length: 0
    < Connection: keep-alive
    < Server: nginx
    < Location: https://d3fo0g5hm7lbuv.cloudfront.net/925/1150/debian/dists/jessie/main/binary-amd64/Packages?Expires=1707610688&Sign...
    ...


This patch add the possibility to follow this redirect, and gets the etag/lastmodify/content from real url.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
```