### PR TITLE
Remove httpclient4 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>apache-httpcomponents-client-4-api</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-job</artifactId>
 			<scope>test</scope>
@@ -150,7 +145,7 @@
 		</pluginRepository>
 	</pluginRepositories>
 
-</project>  
-  
+</project>
+
 
 


### PR DESCRIPTION
Removes outdated `httpclient4` dependency as it is not requried.

### Testing done

`mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
