### PR TITLE
Align Commons IO with Commons Net 3.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,12 @@
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
+			<!-- Commons Net 3.13.0 requires a newer version than the Jenkins BOM provides. -->
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.21.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -147,6 +153,5 @@
 	</pluginRepositories>
 
 </project>
-
 
 


### PR DESCRIPTION
Commons Net 3.13.0 requires Commons IO 2.21.0, while the imported Jenkins BOM manages Commons IO 2.18.0. Maven Enforcer therefore rejects the Dependabot upgrade with a `requireUpperBoundDeps` conflict.

This adds a narrow dependency-management override after the BOM import so Commons Net and its transitive Commons IO dependency resolve to a compatible pair.

Verification:
- `JAVA_HOME=$(/usr/libexec/java_home -v 25) mvn -B -T 1C clean verify`
- 95 tests passed (6 skipped)
- Maven Enforcer upper-bound checks passed
- SpotBugs passed with zero findings
